### PR TITLE
Add a video HTTP caption recipe

### DIFF
--- a/recipes/extracting-captions-http/package.json
+++ b/recipes/extracting-captions-http/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@tvkitchen/example-extracting-captions-http",
+  "version": "0.1.0",
+  "description": "A TV Kitchen instance that extracts closed captions from a video url.",
+  "main": "index.js",
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint 'src/**/*.js' 'lib/**/*.js'",
+    "start": "yarn babel-node src/index.js",
+    "test": "jest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tvkitchen/examples.git",
+    "directory": "extracting-captions"
+  },
+  "keywords": [
+    "tv",
+    "television",
+    "captions"
+  ],
+  "author": "Bad Idea Factory <biffuddotcom@biffud.com>",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/tvkitchen/examples/issues"
+  },
+  "homepage": "https://tv.kitchen",
+  "dependencies": {
+    "@tvkitchen/appliance-ccextractor": "0.2.0",
+    "@tvkitchen/appliance-video-http-ingestion": "0.2.0",
+    "@tvkitchen/base-constants": "^1.2.0",
+    "@tvkitchen/countertop": "0.1.1"
+  },
+  "engines": {
+    "node": ">=13.10"
+  }
+}

--- a/recipes/extracting-captions-http/src/index.js
+++ b/recipes/extracting-captions-http/src/index.js
@@ -1,0 +1,45 @@
+import {
+	applianceEvents,
+	dataTypes,
+} from '@tvkitchen/base-constants'
+import { Countertop } from '@tvkitchen/countertop'
+import { VideoHttpIngestionAppliance } from '@tvkitchen/appliance-video-http-ingestion'
+import { CCExtractorAppliance } from '@tvkitchen/appliance-ccextractor'
+
+const URL_FLAG = '-u'
+
+const countertop = new Countertop()
+
+const getUrl = (args) => {
+	const flagIndex = args.indexOf(URL_FLAG)
+	if (flagIndex === -1 || args.length <= flagIndex + 1) {
+		return ''
+	}
+	return args[flagIndex + 1]
+}
+
+const streamUrl = getUrl(process.argv)
+
+if (streamUrl === '') {
+	console.log(
+		'\x1b[35mERROR:\x1b[0m',
+		'You must pass a url (-u).',
+	)
+	process.exit()
+}
+
+countertop.addAppliance(VideoHttpIngestionAppliance, {
+	url: streamUrl,
+})
+countertop.addAppliance(CCExtractorAppliance)
+
+countertop.on(
+	applianceEvents.PAYLOAD,
+	(payload) => {
+		if (payload.type === dataTypes.TEXT.ATOM) {
+			process.stdout.write(payload.data)
+		}
+	},
+)
+
+countertop.start()

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -2,7 +2,7 @@ import path from 'path'
 import fs from 'fs'
 import { execSync } from 'child_process'
 
-if (process.argv.length !== 3) {
+if (process.argv.length < 3) {
 	console.log(
 		'\x1b[35mERROR:\x1b[0m',
 		'You must pass a recipe name.',
@@ -29,7 +29,9 @@ if (!fs.existsSync(recipePath)) {
 	process.exit()
 }
 
+const scriptParameters = process.argv.slice(3)
+
 execSync(
-	`yarn babel-node ${recipePath}`,
+	`yarn babel-node ${recipePath} ${scriptParameters.join(' ')}`,
 	{ stdio: 'inherit' },
 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -1116,6 +1116,14 @@
   dependencies:
     "@tvkitchen/appliance-core" "0.4.0"
 
+"@tvkitchen/appliance-video-http-ingestion@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@tvkitchen/appliance-video-http-ingestion/-/appliance-video-http-ingestion-0.1.1.tgz#6012157c320bcb89e5aba4461000d723c008a49e"
+  integrity sha512-qVaaQWuc8SoKoxBY+hsnJfhRd0XHMXLedSKoR3TnMwmjADG3bROFxiKBYz3xQJ7B827dzjdVjlay3L+mmz10Ag==
+  dependencies:
+    "@tvkitchen/appliance-core" "0.3.1"
+    node-fetch "^2.6.0"
+
 "@tvkitchen/base-classes@1.4.0-alpha.1":
   version "1.4.0-alpha.1"
   resolved "https://registry.yarnpkg.com/@tvkitchen/base-classes/-/base-classes-1.4.0-alpha.1.tgz#af55076cb06e24907707e3c5f59133b098f830a8"


### PR DESCRIPTION
## Description
This PR adds a new recipe that will generate caption data from an HTTP stream

## Steps to Test
1. `yarn install`
2. `yarn start extracting-captions-http -u {URL_TO_VIDEO}`

## Related Issues
Resolves #8 
