### PR TITLE
Use video receiver appliances

### DIFF
--- a/recipes/extracting-captions-http/package.json
+++ b/recipes/extracting-captions-http/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://tv.kitchen",
   "dependencies": {
     "@tvkitchen/appliance-video-caption-extractor": "0.4.0",
-    "@tvkitchen/appliance-video-http-ingestion": "0.3.1",
+    "@tvkitchen/appliance-video-http-receiver": "0.4.0",
     "@tvkitchen/base-constants": "^1.2.0",
     "@tvkitchen/countertop": "0.2.0"
   },

--- a/recipes/extracting-captions-http/src/index.js
+++ b/recipes/extracting-captions-http/src/index.js
@@ -1,6 +1,6 @@
 import { dataTypes } from '@tvkitchen/base-constants'
 import { Countertop } from '@tvkitchen/countertop'
-import { VideoHttpIngestionAppliance } from '@tvkitchen/appliance-video-http-ingestion'
+import { VideoHttpReceiverAppliance } from '@tvkitchen/appliance-video-http-receiver'
 import { VideoCaptionExtractorAppliance } from '@tvkitchen/appliance-video-caption-extractor'
 
 const URL_FLAG = '-u'
@@ -25,7 +25,7 @@ if (streamUrl === '') {
 	process.exit()
 }
 
-countertop.addAppliance(VideoHttpIngestionAppliance, {
+countertop.addAppliance(VideoHttpReceiverAppliance, {
 	url: streamUrl,
 })
 countertop.addAppliance(VideoCaptionExtractorAppliance)

--- a/recipes/extracting-captions/package.json
+++ b/recipes/extracting-captions/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://tv.kitchen",
   "dependencies": {
     "@tvkitchen/appliance-video-caption-extractor": "0.4.0",
-    "@tvkitchen/appliance-video-file-ingestion": "0.3.1",
+    "@tvkitchen/appliance-video-file-receiver": "0.4.0",
     "@tvkitchen/base-constants": "^1.2.0",
     "@tvkitchen/countertop": "0.2.0"
   },

--- a/recipes/extracting-captions/src/index.js
+++ b/recipes/extracting-captions/src/index.js
@@ -1,7 +1,7 @@
 import path from 'path'
 import { dataTypes } from '@tvkitchen/base-constants'
 import { Countertop } from '@tvkitchen/countertop'
-import { VideoFileIngestionAppliance } from '@tvkitchen/appliance-video-file-ingestion'
+import { VideoFileReceiverAppliance } from '@tvkitchen/appliance-video-file-receiver'
 import { VideoCaptionExtractorAppliance } from '@tvkitchen/appliance-video-caption-extractor'
 
 const countertop = new Countertop({
@@ -10,7 +10,7 @@ const countertop = new Countertop({
 	},
 })
 
-countertop.addAppliance(VideoFileIngestionAppliance, {
+countertop.addAppliance(VideoFileReceiverAppliance, {
 	filePath: path.join(__dirname, '../data/sample.ts'),
 })
 countertop.addAppliance(VideoCaptionExtractorAppliance)


### PR DESCRIPTION
The video "ingestors" are now video "receivers" in order to conform with
the appliance naming conventions we've grown over time.

Issue #20

## Description
This PR replaces references to `Video{X}IngestionAppliance`s and replaces them with `Video{X}ReceiverAppliance`s

## Related Issues
Resolves #20